### PR TITLE
Fixing typo ('messing' -> 'missing')

### DIFF
--- a/demo-setup.md
+++ b/demo-setup.md
@@ -79,7 +79,7 @@ $ CFLAGS='-g -gdwarf4 -DDEBUG -O0 -fno-omit-frame-pointer' \
                 --with-features=huge \
                 --enable-python3interp \
                 --enable-terminal  \
-                --enable-fail-if-messing 
+                --enable-fail-if-missing 
 $ make
 $ make install
 ```


### PR DESCRIPTION
Just happened to notice it as I was going through the setup tutorial.